### PR TITLE
Typing for spectral-clustering and bisecting-kmeans

### DIFF
--- a/docs/bisecting_kmeans.md
+++ b/docs/bisecting_kmeans.md
@@ -10,11 +10,15 @@ Computes the Sum of Squared Errors (SSE) for a given cluster.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$indices`: Indices of the data points belonging to the cluster.
+  - Type: `(NPArray ($M))`
 - `$centers`: The center (mean) of the cluster.
+  - Type: `(NPArray ($C))`
 
 #### Returns:
 - The SSE value computed as the sum of squared differences between the data points and the cluster center.
+  - Type: `Number`
 
 ---
 
@@ -23,13 +27,20 @@ Computes the initial cluster for the dataset.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
-
+  - Type: `(NPArray ($N $D))`
 #### Returns:
-- A tuple containing:
-  - **Indices:** All data point indices in `$X`.
-  - **Center:** The mean of the dataset.
-  - **SSE:** The computed SSE for the cluster.
-  - **Hierarchy:** `pyNone` (as no hierarchy is present initially).
+- A list containing the initial cluster.
+  - Type: `ClusterList`
+
+Where the `ClusterList` is a list of clusters, and each cluster is a tuple containing:
+1. **Indices:** All data point indices in `$X`.
+   - Type: `(NPArray ($N $D))`
+2. **Center:** The mean of the dataset.
+   - Type: `(NPArray ($C))`
+3. **SSE:** The computed SSE for the cluster.
+   - Type: `Number`
+4. **Hierarchy:** `pyNone` (as no hierarchy is present initially).
+   - Type: `Hierarchy`
 
 ---
 
@@ -38,9 +49,11 @@ Extracts the indices from a cluster tuple.
 
 #### Parameters:
 - `$cluster`: A tuple `($indices $center $sse $hierarchy)` representing a cluster.
+  - Type: `Cluster`
 
 #### Returns:
 - The indices of the data points in the cluster.
+  - Type: `(NPArray ($M))`
 
 ---
 
@@ -49,9 +62,11 @@ Extracts the center of the cluster.
 
 #### Parameters:
 - `$cluster`: A tuple representing a cluster.
+  - Type: `Cluster`
 
 #### Returns:
 - The center of the cluster.
+   - Type: `(NPArray ($C))`
 
 ---
 
@@ -60,9 +75,11 @@ Extracts the SSE value from a cluster tuple.
 
 #### Parameters:
 - `$cluster`: A tuple representing a cluster.
+  - Type: `Cluster`
 
 #### Returns:
 - The SSE value of the cluster.
+  - Type: `Number`
 
 ---
 
@@ -71,10 +88,11 @@ Extracts the hierarchical structure information from a cluster tuple.
 
 #### Parameters:
 - `$cluster`: A tuple representing a cluster.
+  - Type: `Cluster`
 
 #### Returns:
 - The hierarchy associated with the cluster.
-
+  - Type: `Hierarchy`
 ---
 
 ### `bisecting-kmeans.find-max-cluster`
@@ -82,9 +100,11 @@ Finds the cluster with the maximum SSE from a list of clusters.
 
 #### Parameters:
 - A list of clusters, where each cluster is a tuple `($indices $center $sse $hierarchy)`.
+  - Type: `ClusterList`
 
 #### Returns:
 - The cluster tuple with the highest SSE value.
+  - Type: `Cluster`
 
 ---
 
@@ -93,10 +113,11 @@ Checks whether two clusters are equal based on their indices, center, and SSE.
 
 #### Parameters:
 - Two cluster tuples: `($indices1 $center1 $sse1 $hierarchy1)` and `($indices2 $center2 $sse2 $hierarchy2)`.
+  - Type: `Cluster Cluster`
 
 #### Returns:
 - `True` if both clusters are equal; otherwise, `False`.
-
+  - Type: `Bool`
 ---
 
 ### `bisecting-kmeans.remove-cluster`
@@ -104,11 +125,13 @@ Removes a target cluster from a list of clusters.
 
 #### Parameters:
 - `$clusters`: The list of current clusters.
+  - Type: `ClusterList`
 - `$target`: The cluster tuple to be removed.
+  - Type: `Cluster`
 
 #### Returns:
 - An updated list of clusters with the target cluster removed.
-
+  - Type: `Cluster`
 ---
 
 ### `bisecting-kmeans.bisect-cluster`
@@ -116,12 +139,15 @@ Performs bisection on a given cluster using standard k-means with k=2.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$max-cluster`: The cluster to be bisected, represented as a tuple.
+  - Type: `Cluster`
 - `$max-iter`: The maximum number of iterations allowed for the k-means algorithm during the bisecting process.
+  - Type: `Number`
 
 #### Returns:
 - A tuple containing two clusters obtained from splitting the input cluster. Each cluster is represented as `(indices, center, sse, hierarchy)`.
-
+  - Type: `ClusterList`
 ---
 
 ### `bisecting-kmeans.recursive-bisecting-kmeans`
@@ -129,14 +155,19 @@ Recursively applies bisecting k-means to further split clusters until the desire
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$clusters`: The current list of clusters.
-- `$max-cluster`: The desired number of clusters.
+  - Type: `ClusterList`
+- `$max-num-clusters`: The desired number of clusters.
+  - Type: `Number`
 - `$max-iter`: The maximum iterations for each bisecting step.
+  - Type: `Number`
 - `$hierarchy`: The current hierarchical clustering structure maintained as a MeTTa list.
+  - Type: `Hierarchy`
 
 #### Returns:
 - An updated hierarchical clustering structure as a MeTTa list describing the clustering process.
-
+  - Type: `Hierarchy`
 ---
 
 ### `bisecting-kmeans.fit`
@@ -144,8 +175,11 @@ Performs bisecting k-means clustering on the dataset.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$max-num-clusters`: The maximum (desired) number of clusters.
+  - Type: `Number`
 - `$max-kmeans-iter`: The maximum number of iterations for the k-means algorithm during the bisecting process.
+  - Type: `Number`
 
 #### Returns:
 - A hierarchical clustering structure as a MeTTa list that describes the sequence of splits performed.
@@ -157,14 +191,19 @@ Assigns a single data point to the closest cluster based on Euclidean distance.
 
 #### Parameters:
 - `$point`: A single data point from the dataset.
+  - Type: `(NPArray ($D))`
 - `$clusters`: A list of clusters.
+  - Type: `ClusterList`
 - `$best-cluster-idx`: The current best cluster index for the point (initial value provided).
+  - Type: `Number`
 - `$best-distance`: The current best distance found (initially set to a high value, such as `pyINF`).
+  - Type: `Number`
 - `$cluster-idx`: The current index being evaluated.
+  - Type: `Number`
 
 #### Returns:
 - The index of the cluster that is closest to the given data point.
-
+  - Type: `Number`
 ---
 
 ### `bisecting-kmeans.assign-all-points`
@@ -172,13 +211,17 @@ Assigns all data points in the dataset to their closest clusters.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($D))`
 - `$clusters`: The list of clusters.
+  - Type: `ClusterList`
 - `$point-idx`: The current index of the data point being processed.
+  - Type: `Number`
 - `$labels`: A list of cluster labels corresponding to the assignment of each data point.
+  - Type: `LabelList`
 
 #### Returns:
 - A list of cluster labels indicating the assignment of each data point in `$X` to the nearest cluster.
-
+  - Type: `LabelList`
 ---
 
 ### `bisecting-kmeans.predict`
@@ -186,11 +229,13 @@ Predicts the cluster membership for each data point based on the final hierarchi
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$hierarchy`: The hierarchical clustering structure generated by `bisecting-kmeans.fit`.
+  - Type: `Hierarchy`
 
 #### Returns:
 - A list of cluster labels indicating the assigned cluster for each data point in the dataset.
-
+  - Type: `LabelList`
 ---
 
 ## Usage

--- a/docs/spectral_clustering.md
+++ b/docs/spectral_clustering.md
@@ -10,10 +10,10 @@ Computes the square norm for each row (data point) in the dataset.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
-
+  - Type: `(NPArray ($N $D))`
 #### Returns:
 - A vector where each element is the sum of squares of the components of the corresponding data point.
-
+  - Type: `(NPArray ($N 1)`
 ---
 
 ### `spectral-clustering.square-distance-matrix`
@@ -21,10 +21,13 @@ Computes the matrix of squared Euclidean distances between each pair of data poi
 
 #### Parameters:
 - `$square-norm-X`: The vector of square norms computed from `$X`.
+  - Type: `(NPArray ($N 1))`
 - `$X`: The dataset.
+  - Type: `(NPArray ($N $D))`
 
 #### Returns:
 - A square matrix where the entry at (i, j) is the squared Euclidean distance between data point *i* and *j*.
+  - Type: `(NPArray ($N $N))`
 
 ---
 
@@ -33,11 +36,13 @@ Generates the RBF (Radial Basis Function) affinity matrix from a squared distanc
 
 #### Parameters:
 - `$sqr-distance-matrix-X`: The matrix of squared distances between data points.
+  - Type: `(NPArray ($N $N))`
 - `$rbf-kernel-sigma`: The sigma parameter for the RBF kernel.
+  - Type: `Number`
 
 #### Returns:
 - A symmetric affinity matrix where each entry represents the similarity between a pair of data points based on the RBF kernel.
-
+  - Type: `(NPArray ($N $N))`
 ---
 
 ### `spectral-clustering.degree`
@@ -45,10 +50,10 @@ Computes the degree of each node (data point) based on the affinity matrix.
 
 #### Parameters:
 - `$W`: The affinity matrix.
-
+  - Type: `(NPArray ($N $N))`
 #### Returns:
 - A vector where each element is the sum of the corresponding row in `$W`.
-
+  - Type: `(NPArray ($N 1))`
 ---
 
 ### `spectral-clustering.inverse-degree-matrix`
@@ -56,10 +61,10 @@ Constructs the inverse degree matrix used for normalization.
 
 #### Parameters:
 - `$degree-W`: The vector of node degrees computed from `$W`.
-
+  - Type: `(NPArray ($N 1))`
 #### Returns:
 - A diagonal matrix where each diagonal element is the inverse square root of the corresponding degree.
-
+  - Type: `(NPArray ($N $N))`
 ---
 
 ### `spectral-clustering.normalized-laplacian`
@@ -67,11 +72,12 @@ Computes the normalized graph Laplacian from the affinity matrix and its inverse
 
 #### Parameters:
 - `$W`: The RBF affinity matrix.
+  - Type: `(NPArray ($N $N))`
 - `$inverse-degree-matrix-W`: The inverse degree matrix computed from `$W`.
-
+  - Type: `(NPArray ($N $N))`
 #### Returns:
 - The normalized Laplacian matrix defined as *I - D^{-1/2} W D^{-1/2}*, where *I* is the identity matrix.
-
+  - Type: (NPArray ($N $N))
 ---
 
 ### `spectral-clustering.eigh`
@@ -79,10 +85,10 @@ Performs eigen-decomposition on a given matrix.
 
 #### Parameters:
 - `$X`: The matrix to decompose (typically the normalized Laplacian).
-
+  - Type: `(NPArray ($N $N))`
 #### Returns:
 - A tuple containing the eigenvalues and eigenvectors of `$X`.
-
+  - Type: `EighResult`
 ---
 
 ### `spectral-clustering.eigenvalues`
@@ -90,10 +96,11 @@ Extracts the eigenvalues from the result of the eigen-decomposition.
 
 #### Parameters:
 - `$eigh-X`: The tuple returned from `spectral-clustering.eigh`.
+  - Type: `EighResult`
 
 #### Returns:
 - A vector containing the eigenvalues.
-
+  - Type: `(NPArray ($N))`
 ---
 
 ### `spectral-clustering.eigenvectors`
@@ -101,10 +108,10 @@ Extracts the eigenvectors from the result of the eigen-decomposition.
 
 #### Parameters:
 - `$eigh-X`: The tuple returned from `spectral-clustering.eigh`.
-
+  - Type: `EighResult`
 #### Returns:
 - A matrix whose columns correspond to the eigenvectors of `$X`.
-
+  - Type: `(NPArray ($N $N))`
 ---
 
 ### `spectral-clustering.eigval-top-k-index`
@@ -112,11 +119,13 @@ Finds the indices corresponding to the smallest *k* eigenvalues (after sorting).
 
 #### Parameters:
 - `$eigval-L`: The vector of eigenvalues.
+  - Type: `(NPArray ($N))`
 - `$k`: The number of top eigenvalue indices to select.
+  - Type: `Number`
 
 #### Returns:
 - A vector of indices for the top *k* eigenvalues.
-
+  - Type: `(NPArray ($N))`
 ---
 
 ### `spectral-clustering.spectral-embeddings`
@@ -124,11 +133,12 @@ Computes the spectral embeddings by selecting the top *k* eigenvectors based on 
 
 #### Parameters:
 - `$eigh-I`: The eigen-decomposition result of the normalized Laplacian.
+  - Type: `EighResult`
 - `$k`: The number of clusters (and hence dimensions for the embeddings).
-
+  - Type: `Number`
 #### Returns:
 - A matrix of spectral embeddings extracted from the selected eigenvectors.
-
+  - Type: `(NPArray ($N $D))`
 ---
 
 ### `spectral-clustering.row-normalize`
@@ -136,9 +146,11 @@ Normalizes each row of a matrix to have unit norm.
 
 #### Parameters:
 - `$X`: A matrix (such as the spectral embeddings).
+  - Type: `(NPArray ($N $D))`
 
 #### Returns:
 - The row-normalized version of `$X`.
+  - Type: `(NPArray ($N $D))`
 
 ---
 
@@ -147,13 +159,17 @@ Clusters the spectral embeddings using the k-means algorithm.
 
 #### Parameters:
 - `$X`: The original dataset.
+  - Type: `(NPArray ($N $D))`
 - `$num-clusters`: The desired number of clusters.
+  - Type: `Number`
 - `$rbf-kernel-sigma`: The sigma parameter for constructing the RBF affinity matrix.
+  - Type: `Number`
 - `$max-kmeans-iter`: The maximum number of iterations for the k-means algorithm.
+  - Type: `Number`
 
 #### Returns:
 - The centroids obtained after clustering the row-normalized spectral embeddings with k-means.
-
+  - Type: `(NPArray ($K $D))`
 ---
 
 ### `spectral-clustering.fit`
@@ -161,13 +177,17 @@ Performs the full spectral clustering process on the dataset.
 
 #### Parameters:
 - `$X`: The dataset, represented as an array of data points.
+  - Type: `(NPArray ($N $D))`
 - `$num-clusters`: The desired number of clusters.
+  - Type: `Number`
 - `$rbf-kernel-sigma`: The sigma parameter for the RBF kernel (default example: `0.1`).
+  - Type: `Number`
 - `$max-kmeans-iter`: The maximum number of iterations for the k-means algorithm (default example: `100`).
+  - Type: `Number`
 
 #### Returns:
 - The tuple containing spectral embeddings and the final centroids computed from clustering the spectral embeddings.
-
+  - Type: `((NPArray ($N $C)) (NPArray ($K $C)))`
 ---
 
 ### `spectral-clustering.predict`
@@ -175,13 +195,15 @@ Predicts the cluster assignment for each data point in the dataset using the spe
 
 #### Parameters:
 - A tuple `($embeddings $centroids)`, where:
-  - `$embeddings`: The spectral embedding matrix.
-  - `$centroids`: The centroids obtained from the clustering step.
+  1. `$embeddings`: The spectral embedding matrix.
+  2. `$centroids`: The centroids obtained from the clustering step.
+  - Type: `((NPArray ($N $C)) (NPArray ($K $C)))`
 - `$num-clusters`: The number of clusters.
+  - Type: `Number`
 
 #### Returns:
 - A vector of cluster labels, one for each data point, determined by assigning each point to the nearest centroid.
-
+  - Type: `((NPArray ($N)))`
 ## Usage
 To perform spectral clustering on a dataset `S` (an `NPArray` of shape `(n, d)`) with a specified number of clusters (e.g., 3), RBF kernel sigma (e.g., `0.1`), and a maximum of 100 iterations for k-means, you can use:
 ```metta

--- a/metta_ul/cluster/bisecting_kmeans.metta
+++ b/metta_ul/cluster/bisecting_kmeans.metta
@@ -22,14 +22,22 @@
     (length (:: ($indices $center $sse $hierarchy) $xs))
     (+ 1 (length $xs))
 )
+
+(: get-first (-> ClusterList Cluster))
 (=
     (get-first (:: $x $y))
     $x
 )
+
+(: get-second (-> ClusterList Cluster))
 (=
     (get-second (:: $x (:: $y ())))
     $y
 )
+
+(: append (-> ClusterList Cluster ClusterList))
+(: append (-> Hierarchy ClusterList Hierarchy))
+(: append (-> LabelList Number LabelList))
 (=
     (append pyNone $a)
     (::
@@ -51,6 +59,7 @@
         (append $xs $a)
     )
 )
+
 (=
     (get-index () $idx)
     pyNone
@@ -142,6 +151,10 @@
 
 ; ===============================================
 
+; Python code:
+; pts = data[indices]
+; np.sum((pts - center) ** 2)
+(: bisecting-kmeans.compute-sse (-> (NPArray ($N $D)) (NPArray ($M)) (NPArray ($C)) Number))
 (=
     (bisecting-kmeans.compute-sse $X $indices $centers)
     (if (> (py-dot $indices size) 0)
@@ -159,6 +172,12 @@
     )
 )
 
+; Python code:
+; n_samples = data.shape[0]
+; indices = np.arange(n_samples)
+; center = np.mean(data, axis=0)
+; sse = compute_sse(data, indices, center)
+(: bisecting-kmeans.compute-initial-cluster (-> (NPArray ($N $D)) ClusterList))
 (=
     (bisecting-kmeans.compute-initial-cluster $X)
     (::
@@ -187,28 +206,35 @@
     )
 )
 
+(: bisecting-kmeans.get-cluster-indices (-> Cluster (NPArray ($M))))
 (=
     (bisecting-kmeans.get-cluster-indices ($indices $center $sse $hierarchy))
     $indices
 )
+
+(: bisecting-kmeans.get-cluster-center (-> Cluster (NPArray ($K $D))))
 (=
     (bisecting-kmeans.get-cluster-center ($indices $center $sse $hierarchy))
     $center
 )
+
+(: bisecting-kmeans.get-cluster-sse (-> Cluster Number))
 (=
     (bisecting-kmeans.get-cluster-sse ($indices $center $sse $hierarchy))
     $sse
 )
+
+(: bisecting-kmeans.get-cluster-hierarchy (-> Cluster Hierarchy))
 (=
     (bisecting-kmeans.get-cluster-hierarchy ($indices $center $sse $hierarchy))
     $hierarchy
 )
 
+(: bisecting-kmeans.find-max-cluster (-> ClusterList Cluster))
 (=
     (bisecting-kmeans.find-max-cluster (:: ($indices $center $sse $hierarchy) ()) )
     ($indices $center $sse $hierarchy)
 )
-
 (=
     (bisecting-kmeans.find-max-cluster
         (:: ($indices1 $center1 $sse1 $hierarchy1)
@@ -225,6 +251,8 @@
     )
 )
 
+
+(: bisecting-kmeans.cluster-equal (-> Cluster Cluster Bool))
 (=
     (bisecting-kmeans.cluster-equal
         ($indices1 $center1 $sse1 $hierarchy1)
@@ -242,6 +270,8 @@
         False
     )
 )
+
+(: bisecting-kmeans.remove-cluster (-> ClusterList Cluster ClusterList))
 (=
     (bisecting-kmeans.remove-cluster () $target)
     ()
@@ -254,6 +284,7 @@
     )
 )
 
+(: bisecting-kmeans.bisect-cluster (-> (NPArray ($N $D)) Cluster Number ClusterList))
 (=
     (bisecting-kmeans.bisect-cluster $X $max-cluster $max-iter)
     (let
@@ -359,9 +390,10 @@
     )
 )
 
+(: bisecting-kmeans.recursive-bisecting-kmeans (-> (NPArray ($N $D)) ClusterList Number Number Hierarchy Hierarchy))
 (=
-    (bisecting-kmeans.recursive-bisecting-kmeans $X $clusters $max-cluster $max-iter $hierarchy)
-    (if (>= (length $clusters) $max-cluster)
+    (bisecting-kmeans.recursive-bisecting-kmeans $X $clusters $max-num-clusters $max-iter $hierarchy)
+    (if (>= (length $clusters) $max-num-clusters)
         $hierarchy
 
         (let
@@ -377,7 +409,7 @@
                     )
                     (get-second $bisect)
                 )
-                $max-cluster
+                $max-num-clusters
                 $max-iter
                 (append
                     $hierarchy
@@ -394,6 +426,7 @@
     )
 )
 
+(: bisecting-kmeans.fit (-> (NPArray ($N $D)) Number Number Hierarchy))
 (=
     (bisecting-kmeans.fit $X $max-num-clusters $max-kmeans-iter)
     (let
@@ -410,6 +443,8 @@
     )
 )
 
+
+(: bisecting-kmeans.assign-point-to-cluster (-> (NPArray ($D)) ClusterList Number Number Number Number))
 (=
     (bisecting-kmeans.assign-point-to-cluster
         $point
@@ -453,6 +488,7 @@
     )
 )
 
+(: bisecting-kmeans.assign-all-points (-> (NPArray ($N $D)) ClusterList Number LabelList LabelList))
 (=
     (bisecting-kmeans.assign-all-points $X $clusters $point-idx $labels)
     (if (>= $point-idx (py-getitem (py-dot $X shape) 0))
@@ -477,6 +513,7 @@
     )
 )
 
+(: bisecting-kmeans.predict (-> (NPArray ($N $D)) Hierarchy LabelList))
 (=
     (bisecting-kmeans.predict $X $hierarchy)
     (bisecting-kmeans.assign-all-points

--- a/metta_ul/cluster/spectral_clustering.metta
+++ b/metta_ul/cluster/spectral_clustering.metta
@@ -84,6 +84,11 @@
 )
 ; ===============================================
 
+(: X (-> (NPArray ($N $D))))
+
+; Python code: np.sum(X**2, axis=1, keepdims=True)
+; Compute squared norms for each point in X, which helps calculate pairwise distances.
+(: spectral-clustering.square-norm (-> (NPArray ($N $D)) (NPArray ($N 1))))
 (=
     (spectral-clustering.square-norm $X)
     (np.sum
@@ -95,6 +100,10 @@
     )
 )
 
+; Python code: sq_norms + sq_norms.T - 2 * np.dot(X, X.T)
+; Compute pairwise squared Euclidean distances using the identity:
+; ||x_i - x_j||^2 = ||x_i||^2 + ||x_j||^2 - 2*x_i*x_j.
+(: spectral-clustering.square-distance-matrix (-> (NPArray ($N 1)) (NPArray ($N $D)) (NPArray ($N $N))))
 (=
     (spectral-clustering.square-distance-matrix $square-norm-X $X)
     (np.sub
@@ -116,6 +125,9 @@
     )
 )
 
+; Python code: np.exp(-sq_dists / (2 * sigma**2))
+; Apply the Gaussian (RBF) kernel to the squared distances, converting them into affinity values.
+(: spectral-clustering.rbf-affinity-matrix (-> (NPArray ($N $N)) Number (NPArray ($N $N))))
 (=
     (spectral-clustering.rbf-affinity-matrix $sqr-distance-matrix-X $rbf-kernel-sigma)
     (np.exp
@@ -135,12 +147,17 @@
     )
 )
 
-
+; Python code: d = np.sum(W, axis=1)
+; Compute the degree for each node by summing its affinities to all other nodes.
+(: spectral-clustering.degree (-> (NPArray ($N $N)) (NPArray ($N 1))))
 (=
     (spectral-clustering.degree $W)
     (np.sum $W 1)
 )
 
+; Python code: np.diag(1.0 / np.sqrt(d))
+; Create the diagonal matrix D^{-1/2} used to normalize the Laplacian.
+(:spectral-clustering.inverse-degree-matrix (-> (NPArray ($N 1)) (NPArray ($N $N))))
 (=
     (spectral-clustering.inverse-degree-matrix $degree-W)
     (np.diag
@@ -153,6 +170,9 @@
     )
 )
 
+; Python code: np.eye(W.shape[0]) - D_inv_sqrt @ W @ D_inv_sqrt
+; Compute the symmetric normalized Laplacian: L_sym = I - D^{-1/2} * W * D^{-1/2}.
+(: spectral-clustering.normalized-laplacian (-> (NPArray ($N $N)) (NPArray ($N $N)) (NPArray ($N $N))))
 (=
     (spectral-clustering.normalized-laplacian $W $inverse-degree-matrix-W)
     (np.sub
@@ -167,26 +187,41 @@
     )
 )
 
-
+; Python code: np.linalg.eigh(L_sym)
+; Compute eigenvalues and eigenvectors of the symmetric Laplacian matrix for spectral embedding.
+(: spectral-clustering.eigh (-> (NPArray ($N $N)) EighResult))
 (=
     (spectral-clustering.eigh $X)
     ((py-dot np linalg.eigh) (to-np $X))
 )
+
+; Python code: np.linalg.eigh(L_sym)[0]
+; Extract eigenvalues of the Laplacian, which reveal important graph structure for clustering.
+(: spectral-clustering.eigenvalues (-> EighResult (NPArray ($N))))
 (=
     (spectral-clustering.eigenvalues $eigh-X)
     ((py-dot $eigh-X __getitem__) 0)
 )
 
+; Python code: np.linalg.eigh(L_sym)[1]
+; Extract eigenvectors of the Laplacian, used as the spectral embedding of the data.
+(: spectral-clustering.eigenvectors (-> EighResult (NPArray ($N $N))))
 (=
     (spectral-clustering.eigenvectors $eigh-X)
     ((py-dot $eigh-X __getitem__) 1)
 )
 
+; Python code: np.argsort(eigenvalues)
+; Get indices that would sort the eigenvalues in ascending order to select the smallest ones.
+(: spectral-clustering.eigval-top-k-index (-> (NPArray ($N)) Number (NPArray ($N))))
 (=
-    (spectral-clustering.eigval-top-k-index $eigval-L $k)
-    ((py-dot (np.argsort $eigval-L) __getitem__) (np.arange $k))
+    (spectral-clustering.eigval-top-k-index $eigval-X $k)
+    ((py-dot (np.argsort $eigval-X) __getitem__) (np.arange $k))
 )
 
+; Python code: eigenvectors[:, idx[:k]]
+; Select the first k eigenvectors corresponding to the smallest eigenvalues for clustering.
+(: spectral-clustering.spectral-embeddings (-> EighResult Number (NPArray ($N $D))))
 (=
     (spectral-clustering.spectral-embeddings $eigh-I $k)
     (np.take
@@ -196,6 +231,9 @@
     )
 )
 
+; Python code: U / np.linalg.norm(U, axis=1, keepdims=True)
+; Normalize each row of the spectral embedding to unit length for stability in k-means clustering.
+(: spectral-clustering.row-normalize (-> (NPArray ($N $D)) (NPArray ($N $D))))
 (=
     (spectral-clustering.row-normalize $X)
     (np.div
@@ -209,6 +247,9 @@
     )
 )
 
+; Python code: kmeans(X=U_norm, k=k, max_iter=max_iter)
+; Apply k-means to the normalized spectral embedding to partition data into k clusters.
+(: spectral-clustering.cluster (-> (NPArray ($N $D)) Number Number Number (NPArray ($K $D))))
 (=
     (spectral-clustering.cluster $X $num-clusters $rbf-kernel-sigma $max-kmeans-iter)
     (kmeans
@@ -244,7 +285,8 @@
     )
 )
 
-
+; Fit spectral clustering algorithm and return spectral embedding and cluster centroids.
+(: spectral-clustering.fit (-> (NPArray ($N $D)) Number Number Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
     (spectral-clustering.fit $X $num-clusters $rbf-kernel-sigma $max-kmeans-iter)
     (let
@@ -279,11 +321,15 @@
 
 )
 
+; Fit spectral clustering algorithm and return spectral embedding and cluster centroids.
+(: spectral-clustering.fit (-> (NPArray ($N $D)) Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
     (spectral-clustering.fit $X $num-clusters)
     (spectral-clustering.fit $X $num-clusters 0.1 100)
 )
 
+; Predict the cluster assignments of data given spectral embeddings, centroids and number of clusters.
+(: spectral-clustering.predict (-> ((NPArray ($N $C)) (NPArray ($K $C))) Number ((NPArray ($N)))))
 (=
     (spectral-clustering.predict ($embeddings $centroids) $num-clusters)
     (np.argmax

--- a/tests/test_spectral_clustering.py
+++ b/tests/test_spectral_clustering.py
@@ -10,20 +10,25 @@ def test_compute_affinity(metta: MeTTa):
         """
         !(import! &self metta_ul:cluster:spectral_clustering)
         
+        (: X-1D-Single (-> (NPArray (1 1))))
         (=
             (X-1D-Single)
-            ((1))
+            (np.array ((1)))
         )
         
+        (: X-1D-Multiple (-> (NPArray (2 1))))
         (=
             (X-1D-Multiple)
-            ((0) (1))
+            (np.array ((0) (1)))
         )
         
+        (: X-2D-Multiple (-> (NPArray (3 2))))
         (=
             (X-2D-Multiple)
-            ((0 0) (0 1) (1 0))
+            (np.array ((0 0) (0 1) (1 0)))
         )
+        
+        (: X-2D-Random (-> (NPArray (10 3))))
         (=
             (X-2D-Random)
             (np.random.rand 10 3)
@@ -35,9 +40,9 @@ def test_compute_affinity(metta: MeTTa):
         ! (spectral-clustering.rbf-affinity-matrix 
                 (spectral-clustering.square-distance-matrix 
                     (spectral-clustering.square-norm 
-                        (np.array (X-1D-Single)) 
+                        (X-1D-Single) 
                     ) 
-                    (np.array (X-1D-Single))
+                    (X-1D-Single)
                 )  
                 1.0
             )
@@ -54,9 +59,9 @@ def test_compute_affinity(metta: MeTTa):
         ! (spectral-clustering.rbf-affinity-matrix 
                 (spectral-clustering.square-distance-matrix 
                     (spectral-clustering.square-norm 
-                        (np.array (X-1D-Multiple)) 
+                        (X-1D-Multiple) 
                     ) 
-                    (np.array (X-1D-Multiple))
+                    (X-1D-Multiple)
                 )  
                 1.0
             )
@@ -71,9 +76,9 @@ def test_compute_affinity(metta: MeTTa):
         ! (spectral-clustering.rbf-affinity-matrix 
                 (spectral-clustering.square-distance-matrix 
                     (spectral-clustering.square-norm 
-                        (np.array (X-2D-Multiple)) 
+                        (X-2D-Multiple) 
                     ) 
-                    (np.array (X-2D-Multiple))
+                    (X-2D-Multiple)
                 )  
                 1.0
             )
@@ -112,9 +117,9 @@ def test_compute_affinity(metta: MeTTa):
         ! (spectral-clustering.rbf-affinity-matrix 
                 (spectral-clustering.square-distance-matrix 
                     (spectral-clustering.square-norm 
-                        (np.array (X-1D-Multiple)) 
+                        (X-1D-Multiple) 
                     ) 
-                    (np.array (X-1D-Multiple))
+                    (X-1D-Multiple)
                 )  
                 1.0
             )
@@ -127,9 +132,9 @@ def test_compute_affinity(metta: MeTTa):
         ! (spectral-clustering.rbf-affinity-matrix 
                 (spectral-clustering.square-distance-matrix 
                     (spectral-clustering.square-norm 
-                        (np.array (X-1D-Multiple)) 
+                        (X-1D-Multiple) 
                     ) 
-                    (np.array (X-1D-Multiple))
+                    (X-1D-Multiple)
                 )  
                 -1.0
             )
@@ -148,17 +153,17 @@ def test_compute_normalized_laplacian(metta: MeTTa):
         
         (=
             (I)
-            ((1 0 0) (0 1 0) (0 0 1))
+            (np.array ((1 0 0) (0 1 0) (0 0 1)))
         )
         
         (=
             (W-2)
-            ((1 1) (1 1))
+            (np.array ((1 1) (1 1)))
         )
         
         (=
             (W-3)
-            ((1 1 1) (1 1 1) (1 1 1))
+            (np.array ((1 1 1) (1 1 1) (1 1 1)))
         )
         (=
             (X-2D-Random)
@@ -169,10 +174,10 @@ def test_compute_normalized_laplacian(metta: MeTTa):
     result: Atom = metta.run(
         """        
         ! (spectral-clustering.normalized-laplacian 
-            (np.array (I)) 
+            (I) 
             (spectral-clustering.inverse-degree-matrix 
                 (spectral-clustering.degree 
-                    (np.array (I))
+                    (I)
                 )
             )
         )
@@ -187,10 +192,10 @@ def test_compute_normalized_laplacian(metta: MeTTa):
     result: Atom = metta.run(
         """        
         ! (spectral-clustering.normalized-laplacian 
-            (np.array (W-2)) 
+            (W-2) 
             (spectral-clustering.inverse-degree-matrix 
                 (spectral-clustering.degree 
-                    (np.array (W-2))
+                    (W-2)
                 )
             )
         )
@@ -205,10 +210,10 @@ def test_compute_normalized_laplacian(metta: MeTTa):
     result: Atom = metta.run(
         """        
         ! (spectral-clustering.normalized-laplacian 
-            (np.array (W-3)) 
+            (W-3) 
             (spectral-clustering.inverse-degree-matrix 
                 (spectral-clustering.degree 
-                    (np.array (W-3))
+                    (W-3)
                 )
             )
         )
@@ -576,6 +581,7 @@ def test_spectral_clustering_fit_and_predict(metta: MeTTa):
             (X)
             (np.array ((0.0 0.0) (0.1 0) (1.0 1.0) (1.1 1.0)))
         )
+        (: fit-outputs (-> ((NPArray (4 2)) (NPArray (2 2)))))
         (=
             (fit-outputs)
             (spectral-clustering.fit (X) 2)


### PR DESCRIPTION
- Initial types for spectral-clustering and bisecting-kmeans algorithms are added to the metta codes and their test functions.
- Initial types are also added to the corresponding docs of each algorithm.