### PR TITLE
Spectral Clustering nearest neighbor affinity matrix mode.

### DIFF
--- a/metta_ul/cluster/spectral_clustering.metta
+++ b/metta_ul/cluster/spectral_clustering.metta
@@ -67,64 +67,15 @@
     )
 )
 
-(: spectral-clustering.compute-rbf-affinity-matrix (-> (NPArray ($N $D)) Number (NPArray ($N $N))))
+(: spectral-clustering.compute-affinity-matrix (-> (NPArray ($N $D)) Number (NPArray ($N $N))))
 (=
-    (spectral-clustering.compute-rbf-affinity-matrix $X $rbf-kernel-sigma)
+    (spectral-clustering.compute-affinity-matrix $X $rbf-kernel-sigma)
     (spectral-clustering.rbf-affinity-matrix
         (spectral-clustering.square-distance-matrix
             (spectral-clustering.square-norm $X)
             $X
         )
         $rbf-kernel-sigma
-    )
-)
-; =================== KNN mode ===================
-(: spectral-clustering.compute-knn-binary-graph-affinity-matrix (-> (NPArray ($N $D)) Number (NPArray ($N $N))))
-(=
-    (spectral-clustering.compute-knn-binary-graph-affinity-matrix $X $n-neighbors)
-    (let
-        $dist
-        (spectral-clustering.square-distance-matrix
-            (spectral-clustering.square-norm $X)
-        $X
-        )
-        (let
-            $N
-            (np.shape $dist 0)
-            (let
-                $end-index
-                (+ 1 $n-neighbors)
-                (let
-                    $knn-indices
-                    (np.take (np.argsort $dist 1) (np.arange 1 $end-index) 1)
-                    (let
-                        $row-index
-                        (np.reshape (np.arange $N) (np.array ($N 1)))
-                        (let
-                            $flat-index
-                            (np.reshape
-                                (np.add (np.mul $row-index $N) $knn-indices)
-                                -1
-                            )
-                            (let
-                                $mask
-                                (np.isin (np.arange (* $N $N)) $flat-index)
-                                (let
-                                    $A-flat
-                                    (np.where $mask 1.0 0.0)
-                                    (let
-                                        $A
-                                        (np.reshape $A-flat (np.array ($N $N)))
-                                        (np.add 0.00000001 (np.maximum $A (np.transpose $A)))
-                                    )
-
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-        )
     )
 )
 
@@ -245,18 +196,12 @@
 )
 
 ; Fit spectral clustering algorithm and return spectral embedding and cluster centroids.
-(: spectral-clustering.fit (-> (NPArray ($N $D)) Number String Number Number ((NPArray ($N $C)) (NPArray ($K $C)))))
+(: spectral-clustering.fit (-> (NPArray ($N $D)) Number Number Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
-    (spectral-clustering.fit $X $num-clusters $affinity-mode $affinity-param $max-kmeans-iter)
+    (spectral-clustering.fit $X $num-clusters $affinity-param $max-kmeans-iter)
     (let
         $affinity-matrix
-        (case
-            $affinity-mode
-            (
-                ("binary-knn-graph" (spectral-clustering.compute-knn-binary-graph-affinity-matrix $X $affinity-param))
-                ("rbf-affinity-matrix" (spectral-clustering.compute-rbf-affinity-matrix $X $affinity-param))
-            )
-        )
+        (spectral-clustering.compute-affinity-matrix $X $affinity-param)
         (let
             $embeddings
             (spectral-clustering.row-normalize
@@ -283,7 +228,7 @@
 (: spectral-clustering.fit (-> (NPArray ($N $D)) Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
     (spectral-clustering.fit $X $num-clusters)
-    (spectral-clustering.fit $X $num-clusters "rbf-affinity-matrix" 0.1 10)
+    (spectral-clustering.fit $X $num-clusters 0.1 10)
 )
 
 ; Predict the cluster assignments of data given spectral embeddings, centroids and number of clusters.

--- a/metta_ul/cluster/spectral_clustering.metta
+++ b/metta_ul/cluster/spectral_clustering.metta
@@ -67,6 +67,68 @@
     )
 )
 
+(: spectral-clustering.compute-rbf-affinity-matrix (-> (NPArray ($N $D)) Number (NPArray ($N $N))))
+(=
+    (spectral-clustering.compute-rbf-affinity-matrix $X $rbf-kernel-sigma)
+    (spectral-clustering.rbf-affinity-matrix
+        (spectral-clustering.square-distance-matrix
+            (spectral-clustering.square-norm $X)
+            $X
+        )
+        $rbf-kernel-sigma
+    )
+)
+; =================== KNN mode ===================
+(: spectral-clustering.compute-knn-binary-graph-affinity-matrix (-> (NPArray ($N $D)) Number (NPArray ($N $N))))
+(=
+    (spectral-clustering.compute-knn-binary-graph-affinity-matrix $X $n-neighbors)
+    (let
+        $dist
+        (spectral-clustering.square-distance-matrix
+            (spectral-clustering.square-norm $X)
+        $X
+        )
+        (let
+            $N
+            (np.shape $dist 0)
+            (let
+                $end-index
+                (+ 1 $n-neighbors)
+                (let
+                    $knn-indices
+                    (np.take (np.argsort $dist 1) (np.arange 1 $end-index) 1)
+                    (let
+                        $row-index
+                        (np.reshape (np.arange $N) (np.array ($N 1)))
+                        (let
+                            $flat-index
+                            (np.reshape
+                                (np.add (np.mul $row-index $N) $knn-indices)
+                                -1
+                            )
+                            (let
+                                $mask
+                                (np.isin (np.arange (* $N $N)) $flat-index)
+                                (let
+                                    $A-flat
+                                    (np.where $mask 1.0 0.0)
+                                    (let
+                                        $A
+                                        (np.reshape $A-flat (np.array ($N $N)))
+                                        (np.add 0.00000001 (np.maximum $A (np.transpose $A)))
+                                    )
+
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+)
+
+; ================================================
 ; Python code: d = np.sum(W, axis=1)
 ; Compute the degree for each node by summing its affinities to all other nodes.
 (: spectral-clustering.degree (-> (NPArray ($N $N)) (NPArray ($N 1))))
@@ -171,9 +233,9 @@
 
 ; Python code: kmeans(X=U_norm, k=k, max_iter=max_iter)
 ; Apply k-means to the normalized spectral embedding to partition data into k clusters.
-(: spectral-clustering.cluster (-> (NPArray ($N $D)) Number Number Number (NPArray ($K $D))))
+(: spectral-clustering.cluster (-> (NPArray ($N $D)) Number Number (NPArray ($K $D))))
 (=
-    (spectral-clustering.cluster $X $num-clusters $rbf-kernel-sigma $max-kmeans-iter)
+    (spectral-clustering.cluster $X $num-clusters $max-kmeans-iter)
     (kmeans.fit
         $X
         $num-clusters
@@ -183,17 +245,17 @@
 )
 
 ; Fit spectral clustering algorithm and return spectral embedding and cluster centroids.
-(: spectral-clustering.fit (-> (NPArray ($N $D)) Number Number Number ((NPArray ($N $C)) (NPArray ($K $C)))))
+(: spectral-clustering.fit (-> (NPArray ($N $D)) Number String Number Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
-    (spectral-clustering.fit $X $num-clusters $rbf-kernel-sigma $max-kmeans-iter)
+    (spectral-clustering.fit $X $num-clusters $affinity-mode $affinity-param $max-kmeans-iter)
     (let
         $affinity-matrix
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm $X)
-                $X
+        (case
+            $affinity-mode
+            (
+                ("binary-knn-graph" (spectral-clustering.compute-knn-binary-graph-affinity-matrix $X $affinity-param))
+                ("rbf-affinity-matrix" (spectral-clustering.compute-rbf-affinity-matrix $X $affinity-param))
             )
-            $rbf-kernel-sigma
         )
         (let
             $embeddings
@@ -212,7 +274,7 @@
                     $num-clusters
                 )
             )
-            ($embeddings (spectral-clustering.cluster $embeddings $num-clusters $rbf-kernel-sigma $max-kmeans-iter))
+            ($embeddings (spectral-clustering.cluster $embeddings $num-clusters $max-kmeans-iter))
         )
     )
 )
@@ -221,7 +283,7 @@
 (: spectral-clustering.fit (-> (NPArray ($N $D)) Number ((NPArray ($N $C)) (NPArray ($K $C)))))
 (=
     (spectral-clustering.fit $X $num-clusters)
-    (spectral-clustering.fit $X $num-clusters 0.1 10)
+    (spectral-clustering.fit $X $num-clusters "rbf-affinity-matrix" 0.1 10)
 )
 
 ; Predict the cluster assignments of data given spectral embeddings, centroids and number of clusters.

--- a/metta_ul/numme.py
+++ b/metta_ul/numme.py
@@ -218,6 +218,7 @@ def numme_atoms():
     nmRepeat = G(PatternOperation("np.repeat", wrapnpop(np.repeat), unwrap=False))
     nmEye = G(PatternOperation("np.eye", wrapnpop(np.eye), unwrap=False))
     nmOnes = G(PatternOperation("np.ones", wrapnpop(np.ones), unwrap=False))
+    nmZeros = G(PatternOperation("np.zeros", wrapnpop(np.zeros), unwrap=False))
     nmPower = G(PatternOperation("np.power", wrapnpop(np.power), unwrap=False))
     nmRandomRand = G(
         PatternOperation("np.random.rand", wrapnpop(np.random.rand), unwrap=False)
@@ -230,6 +231,7 @@ def numme_atoms():
 
     nmSlice = G(PatternOperation("np.slice", wrapnpop(_slice), unwrap=False))
     nmArgmax = G(PatternOperation("np.argmax", wrapnpop(np.argmax), unwrap=False))
+    nmMaximum = G(PatternOperation("np.maximum", wrapnpop(np.maximum), unwrap=False))
     nmIx_ = G(PatternOperation("np.ix_", wrapnpop(np.ix_), unwrap=False, rec=False))
     nmMin = G(PatternOperation("np.min", wrapnpop(np.min), unwrap=False))
     nmMax = G(PatternOperation("np.max", wrapnpop(np.max), unwrap=False))
@@ -244,6 +246,7 @@ def numme_atoms():
         )
     )
     nmWhere = G(PatternOperation("np.where", wrapnpop(np.where), unwrap=False))
+    nmIsin = G(PatternOperation("np.isin", wrapnpop(np.isin), unwrap=False))
     nmEqual = G(PatternOperation("np.equal", wrapnpop(np.equal), unwrap=False))
     nmAppend = G(PatternOperation("np.append", wrapnpop(np.append)))
     nmPut = G(PatternOperation("np.put", wrapnpop(np.put), unwrap=False))
@@ -259,6 +262,7 @@ def numme_atoms():
         PatternOperation("py.assertIsNone", _assert_isNone, unwrap=False)
     )
     nmSort = G(PatternOperation("np.sort", wrapnpop(np.sort), unwrap=False))
+    nmReshape = G(PatternOperation("np.reshape", wrapnpop(np.reshape), unwrap=False))
 
     pyNone = ValueAtom(None)
     pyTrue = ValueAtom(True)
@@ -325,4 +329,8 @@ def numme_atoms():
         "np.True_": nmTrue,
         "py.assertIsNone": nmAssertIsNone,
         "np.sort": nmSort,
+        "np.reshape": nmReshape,
+        "np.zeros": nmZeros,
+        "np.isin": nmIsin,
+        "np.maximum": nmMaximum
     }

--- a/tests/test_spectral_clustering.metta
+++ b/tests/test_spectral_clustering.metta
@@ -117,7 +117,7 @@
     (spectral-clustering.rbf-affinity-matrix.test1)
     (let
         $W
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-1D-Single)
             1.0
         )
@@ -138,7 +138,7 @@
     (spectral-clustering.rbf-affinity-matrix.test2)
     (let
         $W
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-1D-Multiple)
             1.0
         )
@@ -161,7 +161,7 @@
     (spectral-clustering.rbf-affinity-matrix.test3)
     (let
         $W
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-2D-Multiple)
             1.0
         )
@@ -184,7 +184,7 @@
     (spectral-clustering.rbf-affinity-matrix.test4)
     (let
         $W
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-2D-Multiple)
             1.0
         )
@@ -207,7 +207,7 @@
     (spectral-clustering.rbf-affinity-matrix.test5)
     (let
         $W
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-2D-Random-1)
             1.0
         )
@@ -307,7 +307,7 @@
     (spectral-clustering.normalized-laplacian.test4)
     (let
         $W-X-2D-Random
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X-2D-Random-2)
             1.0
         )
@@ -553,7 +553,7 @@
     (spectral-clustering.cluster.test1)
     (let
         $W-X1
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X1)
             0.1
         )
@@ -597,7 +597,7 @@
     (spectral-clustering.cluster.test2)
     (let
         $W-X2
-        (spectral-clustering.compute-rbf-affinity-matrix
+        (spectral-clustering.compute-affinity-matrix
             (X2)
             0.1
         )
@@ -661,11 +661,29 @@
 )
 (Test spectral-clustering.fit-predict.test1)
 
+! (match &self (= (spectral-clustering.compute-affinity-matrix $X $rbf-kernel-sigma) $Expression) (remove-atom &self (= (spectral-clustering.compute-affinity-matrix $X $rbf-kernel-sigma) $Expression)))
+(=
+    (spectral-clustering.compute-affinity-matrix $X $n-neighbors)
+    (let*
+        (
+            ($dist (spectral-clustering.square-distance-matrix (spectral-clustering.square-norm $X) $X))
+            ($N (np.shape $dist 0))
+            ($end-index (+ 1 $n-neighbors))
+            ($knn-indices (np.take (np.argsort $dist 1) (np.arange 1 $end-index) 1))
+            ($row-index (np.reshape (np.arange $N) (np.array ($N 1))))
+            ($flat-index (np.reshape (np.add (np.mul $row-index $N) $knn-indices) -1))
+            ($mask (np.isin (np.arange (* $N $N)) $flat-index))
+            ($A-flat (np.where $mask 1.0 0.0))
+            ($A (np.reshape $A-flat (np.array ($N $N))))
+        )
+        (np.add 0.00000001 (np.maximum $A (np.transpose $A)))
+    )
+)
 (=
     (spectral-clustering.fit-predict.test2)
     (let
         $fit-outputs
-        (spectral-clustering.fit (X-Fit) 2 "binary-knn-graph" 1 100)
+        (spectral-clustering.fit (X-Fit) 2 1 100)
         (let
             $pred
             (spectral-clustering.predict $fit-outputs 2)

--- a/tests/test_spectral_clustering.metta
+++ b/tests/test_spectral_clustering.metta
@@ -117,13 +117,8 @@
     (spectral-clustering.rbf-affinity-matrix.test1)
     (let
         $W
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-1D-Single)
-                )
-                (X-1D-Single)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-1D-Single)
             1.0
         )
 
@@ -143,13 +138,8 @@
     (spectral-clustering.rbf-affinity-matrix.test2)
     (let
         $W
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-1D-Multiple)
-                )
-                (X-1D-Multiple)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-1D-Multiple)
             1.0
         )
 
@@ -171,13 +161,8 @@
     (spectral-clustering.rbf-affinity-matrix.test3)
     (let
         $W
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-2D-Multiple)
-                )
-                (X-2D-Multiple)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-2D-Multiple)
             1.0
         )
 
@@ -199,13 +184,8 @@
     (spectral-clustering.rbf-affinity-matrix.test4)
     (let
         $W
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-2D-Multiple)
-                )
-                (X-2D-Multiple)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-2D-Multiple)
             1.0
         )
 
@@ -227,13 +207,8 @@
     (spectral-clustering.rbf-affinity-matrix.test5)
     (let
         $W
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-2D-Random-1)
-                )
-                (X-2D-Random-1)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-2D-Random-1)
             1.0
         )
 
@@ -332,13 +307,8 @@
     (spectral-clustering.normalized-laplacian.test4)
     (let
         $W-X-2D-Random
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm
-                    (X-2D-Random-2)
-                )
-                (X-2D-Random-2)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X-2D-Random-2)
             1.0
         )
         (let
@@ -583,11 +553,8 @@
     (spectral-clustering.cluster.test1)
     (let
         $W-X1
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm (X1))
-                (X1)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X1)
             0.1
         )
         (let
@@ -611,7 +578,7 @@
                     (np.transpose
                         (kmeans.assign
                             $U-X1
-                            (spectral-clustering.cluster $U-X1 (K1) 0.1 10)
+                            (spectral-clustering.cluster $U-X1 (K1) 10)
                         )
                     )
                     1
@@ -630,11 +597,8 @@
     (spectral-clustering.cluster.test2)
     (let
         $W-X2
-        (spectral-clustering.rbf-affinity-matrix
-            (spectral-clustering.square-distance-matrix
-                (spectral-clustering.square-norm (X2))
-                (X2)
-            )
+        (spectral-clustering.compute-rbf-affinity-matrix
+            (X2)
             0.1
         )
         (let
@@ -658,7 +622,7 @@
                     (np.transpose
                         (kmeans.assign
                             $U-X2
-                            (spectral-clustering.cluster $U-X2 (K2) 0.1 10)
+                            (spectral-clustering.cluster $U-X2 (K2) 10)
                         )
                     )
                     1
@@ -697,3 +661,23 @@
 )
 (Test spectral-clustering.fit-predict.test1)
 
+(=
+    (spectral-clustering.fit-predict.test2)
+    (let
+        $fit-outputs
+        (spectral-clustering.fit (X-Fit) 2 "binary-knn-graph" 1 100)
+        (let
+            $pred
+            (spectral-clustering.predict $fit-outputs 2)
+            (assertEqual
+                (
+                    (np.assertAllClose (np.slice $pred [0]) (np.slice $pred [1]))
+                    (np.assertAllClose (np.slice $pred [-2]) (np.slice $pred [-1]))
+                    (np.assertAllClose (np.unique $pred) (np.array (0 1)))
+                )
+                (() () ())
+            )
+        )
+    )
+)
+(Test spectral-clustering.fit-predict.test2)


### PR DESCRIPTION
Binary KNN graph affinity matrix mode is added to Spectral Clustering to illustrate the ability of using different affinity matrices. Default affinity matrix is kept as RBF kernel. Tests and docs are updated accordingly.