### PR TITLE
Using linkedlists

### DIFF
--- a/docs/bisecting-kmeans-api-reference.md
+++ b/docs/bisecting-kmeans-api-reference.md
@@ -3,6 +3,14 @@
 ## Overview
 This module implements the Bisecting K-means clustering algorithm using iterative splitting of clusters. The algorithm starts with the entire dataset as a single cluster and recursively bisects the cluster with the maximum Sum of Squared Errors (SSE) using standard k-means (with k=2) until a desired number of clusters is reached. The resulting hierarchical clustering structure captures the splits performed during the process.
 
+## Type Definitions
+
+### Core Types
+- `Cluster`: A tuple `($indices $center $sse $hierarchy)` representing a single cluster
+- `(List Cluster)`: A typed list of clusters using `Cons` and `Nil` constructors
+- `(List (List Cluster))`: Represents the hierarchical clustering structure
+
+
 ## Function Definitions
 
 ### `bisecting-kmeans.compute-sse`
@@ -30,9 +38,11 @@ Computes the initial cluster for the dataset.
   - Type: `(NPArray ($N $D))`
 #### Returns:
 - A list containing the initial cluster.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 
-Where the `ClusterList` is a list of clusters, and each cluster is a tuple containing:
+Where the `(List Cluster)
+` is a list of clusters, and each cluster is a tuple containing:
 1. **Indices:** All data point indices in `$X`.
    - Type: `(NPArray ($N $D))`
 2. **Center:** The mean of the dataset.
@@ -40,7 +50,7 @@ Where the `ClusterList` is a list of clusters, and each cluster is a tuple conta
 3. **SSE:** The computed SSE for the cluster.
    - Type: `Number`
 4. **Hierarchy:** `pyNone` (as no hierarchy is present initially).
-   - Type: `Hierarchy`
+   - Type: `(List (List Cluster))`
 
 ---
 
@@ -92,7 +102,7 @@ Extracts the hierarchical structure information from a cluster tuple.
 
 #### Returns:
 - The hierarchy associated with the cluster.
-  - Type: `Hierarchy`
+  - Type: `(List (List Cluster))`
 ---
 
 ### `bisecting-kmeans.find-max-cluster`
@@ -100,7 +110,8 @@ Finds the cluster with the maximum SSE from a list of clusters.
 
 #### Parameters:
 - A list of clusters, where each cluster is a tuple `($indices $center $sse $hierarchy)`.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 
 #### Returns:
 - The cluster tuple with the highest SSE value.
@@ -125,7 +136,8 @@ Removes a target cluster from a list of clusters.
 
 #### Parameters:
 - `$clusters`: The list of current clusters.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 - `$target`: The cluster tuple to be removed.
   - Type: `Cluster`
 
@@ -147,7 +159,8 @@ Performs bisection on a given cluster using standard k-means with k=2.
 
 #### Returns:
 - A tuple containing two clusters obtained from splitting the input cluster. Each cluster is represented as `(indices, center, sse, hierarchy)`.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 ---
 
 ### `bisecting-kmeans.recursive-bisecting-kmeans`
@@ -157,17 +170,18 @@ Recursively applies bisecting k-means to further split clusters until the desire
 - `$X`: The dataset, represented as an array of data points.
   - Type: `(NPArray ($N $D))`
 - `$clusters`: The current list of clusters.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 - `$max-num-clusters`: The desired number of clusters.
   - Type: `Number`
 - `$max-iter`: The maximum iterations for each bisecting step.
   - Type: `Number`
 - `$hierarchy`: The current hierarchical clustering structure maintained as a MeTTa list.
-  - Type: `Hierarchy`
+  - Type: `(List (List Cluster))`
 
 #### Returns:
 - An updated hierarchical clustering structure as a MeTTa list describing the clustering process.
-  - Type: `Hierarchy`
+  - Type: `(List (List Cluster))`
 ---
 
 ### `bisecting-kmeans.fit`
@@ -193,7 +207,8 @@ Assigns a single data point to the closest cluster based on Euclidean distance.
 - `$point`: A single data point from the dataset.
   - Type: `(NPArray ($D))`
 - `$clusters`: A list of clusters.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 - `$best-cluster-idx`: The current best cluster index for the point (initial value provided).
   - Type: `Number`
 - `$best-distance`: The current best distance found (initially set to a high value, such as `pyINF`).
@@ -213,15 +228,16 @@ Assigns all data points in the dataset to their closest clusters.
 - `$X`: The dataset, represented as an array of data points.
   - Type: `(NPArray ($D))`
 - `$clusters`: The list of clusters.
-  - Type: `ClusterList`
+  - Type: `(List Cluster)
+`
 - `$point-idx`: The current index of the data point being processed.
   - Type: `Number`
 - `$labels`: A list of cluster labels corresponding to the assignment of each data point.
-  - Type: `LabelList`
+  - Type: `(NPArray ($N))`
 
 #### Returns:
 - A list of cluster labels indicating the assignment of each data point in `$X` to the nearest cluster.
-  - Type: `LabelList`
+  - Type: `(NPArray ($N))`
 ---
 
 ### `bisecting-kmeans.predict`
@@ -231,11 +247,11 @@ Predicts the cluster membership for each data point based on the final hierarchi
 - `$X`: The dataset, represented as an array of data points.
   - Type: `(NPArray ($N $D))`
 - `$hierarchy`: The hierarchical clustering structure generated by `bisecting-kmeans.fit`.
-  - Type: `Hierarchy`
+  - Type: `(List (List Cluster))`
 
 #### Returns:
 - A list of cluster labels indicating the assigned cluster for each data point in the dataset.
-  - Type: `LabelList`
+  - Type: `(NPArray ($N))`
 ---
 
 ## Usage

--- a/metta_ul/cluster/bisecting_kmeans.metta
+++ b/metta_ul/cluster/bisecting_kmeans.metta
@@ -1,5 +1,7 @@
 !(import! &self metta_ul)
 !(import! &self kmeans)
+!(import! &self metta_ul:linkedlist)
+
 
 ! (bind! bc-np (py-atom numpy))
 
@@ -11,84 +13,30 @@
         $index
     )
 )
-(=
-    (length ())
-    0
-)
-(=
-    (length (:: ($indices $center $sse $hierarchy) $xs))
-    (+ 1 (length $xs))
-)
 
+(: get-first (-> (List Cluster) Cluster))
 (=
-    (len ())
-    0
-)
-(=
-    (len (:: $x $xs))
-    (+ 1 (len $xs))
-)
-
-(: get-first (-> ClusterList Cluster))
-(=
-    (get-first (:: $x $y))
+    (get-first (Cons $x $y))
     $x
 )
 
-(: get-second (-> ClusterList Cluster))
+(: get-second (-> (List Cluster) Cluster))
 (=
-    (get-second (:: $x (:: $y ())))
+    (get-second (Cons $x (Cons $y Nil)))
     $y
 )
 
-(: append (-> ClusterList Cluster ClusterList))
-(: append (-> Hierarchy ClusterList Hierarchy))
-(: append (-> LabelList Number LabelList))
 (=
-    (append py.none $a)
-    (::
-        $a
-        ()
-    )
-)
-(=
-    (append () $a)
-    (::
-        $a
-        ()
-    )
-)
-(=
-    (append (:: $x $xs) $a)
-    (::
-        $x
-        (append $xs $a)
-    )
-)
-
-(=
-    (get-index () $idx)
-    py.none
-)
-
-(=
-    (get-index (:: $x $xs) $idx)
-    (if (== $idx 0)
-        $x
-        (get-index $xs (- $idx 1))
-    )
-)
-(=
-    (get-last ())
+    (get-last Nil)
     py.none
 )
 (=
-    (get-last (:: $x ()))
+    (get-last (Cons $x Nil))
     $x
 )
 (=
-    (get-last (:: $x (:: $y $ys)))
-    (get-last (:: $y $ys))
+    (get-last (Cons $x (Cons $y $ys)))
+    (get-last (Cons $y $ys))
 )
 
 ; =========================================
@@ -118,10 +66,10 @@
 ; indices = np.arange(n_samples)
 ; center = np.mean(data, axis=0)
 ; sse = compute_sse(data, indices, center)
-(: bisecting-kmeans.compute-initial-cluster (-> (NPArray ($N $D)) ClusterList))
+(: bisecting-kmeans.compute-initial-cluster (-> (NPArray ($N $D)) (List Cluster)))
 (=
     (bisecting-kmeans.compute-initial-cluster $X)
-    (::
+    (Cons
         (
             ; indices
             (np.arange
@@ -143,7 +91,7 @@
             ; hierarchy
             py.none
         )
-        ()
+        Nil
     )
 )
 
@@ -171,26 +119,27 @@
     $hierarchy
 )
 
-(: bisecting-kmeans.find-max-cluster (-> ClusterList Cluster))
+(: bisecting-kmeans.find-max-cluster (-> (List Cluster) Cluster))
 (=
-    (bisecting-kmeans.find-max-cluster (:: ($indices $center $sse $hierarchy) ()) )
+    (bisecting-kmeans.find-max-cluster (Cons ($indices $center $sse $hierarchy) Nil) )
     ($indices $center $sse $hierarchy)
 )
 (=
     (bisecting-kmeans.find-max-cluster
-        (:: ($indices1 $center1 $sse1 $hierarchy1)
-        (:: ($indices2 $center2 $sse2 $hierarchy2) $xs))
+        (Cons ($indices1 $center1 $sse1 $hierarchy1)
+        (Cons ($indices2 $center2 $sse2 $hierarchy2) $xs))
     )
     (if (>
         $sse1
         (bisecting-kmeans.get-cluster-sse
-            (bisecting-kmeans.find-max-cluster (:: ($indices2 $center2 $sse2 $hierarchy2) $xs))
+            (bisecting-kmeans.find-max-cluster (Cons ($indices2 $center2 $sse2 $hierarchy2) $xs))
         )
     )
          ($indices1 $center1 $sse1 $hierarchy1)
-         (bisecting-kmeans.find-max-cluster (:: ($indices2 $center2 $sse2 $hierarchy2) $xs))
+         (bisecting-kmeans.find-max-cluster (Cons ($indices2 $center2 $sse2 $hierarchy2) $xs))
     )
 )
+
 
 
 (: bisecting-kmeans.cluster-equal (-> Cluster Cluster Bool))
@@ -212,20 +161,20 @@
     )
 )
 
-(: bisecting-kmeans.remove-cluster (-> ClusterList Cluster ClusterList))
+(: bisecting-kmeans.remove-cluster (-> (List Cluster) Cluster (List Cluster)))
 (=
-    (bisecting-kmeans.remove-cluster () $target)
-    ()
+    (bisecting-kmeans.remove-cluster Nil $target)
+    Nil
 )
 (=
-    (bisecting-kmeans.remove-cluster (:: ($indices $center $sse $hierarchy) $xs) $target)
+    (bisecting-kmeans.remove-cluster (Cons ($indices $center $sse $hierarchy) $xs) $target)
     (if (bisecting-kmeans.cluster-equal ($indices $center $sse $hierarchy) $target)
         (bisecting-kmeans.remove-cluster $xs $target)
-        (:: ($indices $center $sse $hierarchy) (bisecting-kmeans.remove-cluster $xs $target))
+        (Cons ($indices $center $sse $hierarchy) (bisecting-kmeans.remove-cluster $xs $target))
     )
 )
 
-(: bisecting-kmeans.bisect-cluster (-> (NPArray ($N $D)) Cluster Number ClusterList))
+(: bisecting-kmeans.bisect-cluster (-> (NPArray ($N $D)) Cluster Number (List Cluster)))
 (=
     (bisecting-kmeans.bisect-cluster $X $max-cluster $max-iter)
     (let
@@ -234,7 +183,7 @@
         (kmeans.fit (np.take $X (bisecting-kmeans.get-cluster-indices $max-cluster) 0) 2)
 
         ; output tuple
-        (::
+        (Cons
             ; cluster 0
             (
                 (np.take
@@ -278,7 +227,7 @@
                 )
                 py.none
             )
-            (::
+            (Cons
                 ; cluster 1
                 (
                     (np.take
@@ -321,16 +270,16 @@
                     )
                     py.none
                 )
-                ()
+                Nil
             )
         )
     )
 )
 
-(: bisecting-kmeans.recursive-bisecting-kmeans (-> (NPArray ($N $D)) ClusterList Number Number Hierarchy Hierarchy))
+(: bisecting-kmeans.recursive-bisecting-kmeans (-> (NPArray ($N $D)) (List Cluster) Number Number (List (List Cluster)) (List (List Cluster))))
 (=
     (bisecting-kmeans.recursive-bisecting-kmeans $X $clusters $max-num-clusters $max-iter $hierarchy)
-    (if (>= (length $clusters) $max-num-clusters)
+    (if (>= (List.length $clusters) $max-num-clusters)
         $hierarchy
 
         (let
@@ -339,8 +288,8 @@
 
             (bisecting-kmeans.recursive-bisecting-kmeans
                 $X
-                (append
-                    (append
+                (List.appendElement
+                    (List.appendElement
                         (bisecting-kmeans.remove-cluster $clusters (bisecting-kmeans.find-max-cluster $clusters))
                         (get-first $bisect)
                     )
@@ -348,10 +297,10 @@
                 )
                 $max-num-clusters
                 $max-iter
-                (append
+                (List.appendElement
                     $hierarchy
-                    (append
-                        (append
+                    (List.appendElement
+                        (List.appendElement
                             (bisecting-kmeans.remove-cluster $clusters (bisecting-kmeans.find-max-cluster $clusters))
                             (get-first $bisect)
                         )
@@ -363,7 +312,7 @@
     )
 )
 
-(: bisecting-kmeans.fit (-> (NPArray ($N $D)) Number Number Hierarchy))
+(: bisecting-kmeans.fit (-> (NPArray ($N $D)) Number Number (List (List Cluster))))
 (=
     (bisecting-kmeans.fit $X $max-num-clusters $max-kmeans-iter)
     (let
@@ -375,30 +324,31 @@
             $init-cluster
             $max-num-clusters
             $max-kmeans-iter
-            (append py.none $init-cluster)
+            (List.appendElement Nil $init-cluster)
         )
     )
 )
 
 (=
-    (bisecting-kmeans.extract-centers ())
-    ()
+    (bisecting-kmeans.extract-centers Nil)
+    Nil
 )
 (=
-    (bisecting-kmeans.extract-centers (:: ($indices $center $sse $hierarchy) $rest))
-    (:: $center (bisecting-kmeans.extract-centers $rest))
+    (bisecting-kmeans.extract-centers (Cons ($indices $center $sse $hierarchy) $rest))
+    (Cons $center (bisecting-kmeans.extract-centers $rest))
 )
 
+(: bisecting-kmeans.concat-arrays (-> (List (NPArray ($D))) (NPArray ($N $D))))
 (=
-    (bisecting-kmeans.concat-arrays ())
+    (bisecting-kmeans.concat-arrays Nil)
     (np.array ())
 )
 (=
-    (bisecting-kmeans.concat-arrays (:: $first ()))
+    (bisecting-kmeans.concat-arrays (Cons $first Nil))
     (np.expand_dims $first 0)
 )
 (=
-    (bisecting-kmeans.concat-arrays (:: $first $rest))
+    (bisecting-kmeans.concat-arrays (Cons $first $rest))
     (np.append
         (np.expand_dims $first 0)
         (bisecting-kmeans.concat-arrays $rest)
@@ -420,7 +370,7 @@
 )
 
 
-(: bisecting-kmeans.predict (-> (NPArray ($N $D)) Hierarchy (NPArray ($N))))
+(: bisecting-kmeans.predict (-> (NPArray ($N $D)) (List (List Cluster)) (NPArray ($N))))
 (=
     (bisecting-kmeans.predict $X $hierarchy)
     (bisecting-kmeans.assign

--- a/metta_ul/linkedlist.metta
+++ b/metta_ul/linkedlist.metta
@@ -61,6 +61,15 @@
     (Cons $x (List.append $y $xs))
 )
 
+(: List.appendElement (-> (List $a) $a (List $a)))
+(= (List.appendElement Nil $a)
+   (if (== $a Nil) Nil (Cons $a Nil)))
+(= (List.appendElement (Cons $x $xs) $a)
+   (if (== $a Nil)
+       (Cons $x $xs)
+       (Cons $x (List.appendElement $xs $a))))
+
+
 (: List.length (-> (List $a) Number))
 (= (List.length Nil) 0)
 (= (List.length (Cons $x $xs)) (+ 1 (List.length $xs)))

--- a/tests/test_bisecting_kmeans.metta
+++ b/tests/test_bisecting_kmeans.metta
@@ -62,21 +62,21 @@
 
 (=
     (clusters1)
-    (::
+    (Cons
         (py.none py.none 10.0 py.none)
-        ()
+        Nil
     )
 )
 
 (=
     (clusters2)
-    (::
+    (Cons
         (py.none py.none 10.0 py.none)
-        (::
+        (Cons
             (py.none py.none 20.0 py.none)
-            (::
+            (Cons
                 (py.none py.none 5.0 py.none)
-                ()
+                Nil
             )
         )
     )
@@ -84,13 +84,13 @@
 
 (=
     (clusters3)
-    (::
+    (Cons
         ((np.array (0)) py.none 1.0 py.none)
-        (::
+        (Cons
             ((np.array (1)) py.none 2.0 py.none)
-            (::
+            (Cons
                 ((np.array (2)) py.none 3.0 py.none)
-                ()
+                Nil
             )
         )
     )
@@ -98,18 +98,18 @@
 
 (=
     (clusters4)
-    (::
+    (Cons
         ((np.array (1)) py.none 2.0 py.none)
-        (::
+        (Cons
             ((np.array (2)) py.none 3.0 py.none)
-            ()
+            Nil
         )
     )
 )
 
 (=
     (clusters5)
-    ()
+    Nil
 )
 
 (=
@@ -119,14 +119,14 @@
 
 (=
     (clusters6)
-    (::
+    (Cons
         (
             (np.array (0 1 2 3))
             (np.array (5.0 5.5))
             201.0
             py.none
         )
-        ()
+        Nil
     )
 )
 
@@ -134,6 +134,61 @@
     (X6)
     (np.array ((0.0 0.0) (0.0 1.0) (1.0 0.0) (1.0 1.0) (5.0 5.0) (5.0 6.0)))
 )
+
+;; Test clusters for extract-centers and assign functions
+(=
+    (test-clusters-extract)
+    (Cons
+        (
+            (np.array (0 1))
+            (np.array (1.0 1.0))
+            10.5
+            py.none
+        )
+        (Cons
+            (
+                (np.array (3 4))
+                (np.array (2.0 2.0))
+                5.2
+                py.none
+            )
+            Nil
+        )
+    )
+)
+
+;; Test data for assign function
+(=
+    (X-assign)
+    (np.array (
+        (0.5 0.5)
+        (1.5 1.5)
+        (4.5 4.5)
+        (5.5 5.5)
+    ))
+)
+
+(=
+    (test-clusters-assign)
+    (Cons
+        (
+            (np.array (0 1))
+            (np.array (1.0 1.0))
+            10.5
+            py.none
+        )
+        (Cons
+            (
+                (np.array (2 3))
+                (np.array (5.0 5.0))
+                5.2
+                py.none
+            )
+            Nil
+        )
+    )
+)
+
 ;; ========================================================================
 ;; =================== Test bisecting-kmeans.compute-sse ==================
 ;; ========================================================================
@@ -178,7 +233,7 @@
         (bisecting-kmeans.compute-initial-cluster (X4))
         (assertEqual
             (
-                (np.assertAllClose (length $init-cluster-list) 1)
+                (np.assertAllClose (List.length $init-cluster-list) 1)
                 (np.assertAllClose
                     (bisecting-kmeans.get-cluster-indices (get-first $init-cluster-list))
                     (np.arange (np.shape (X4) 0))
@@ -296,7 +351,7 @@
         (bisecting-kmeans.remove-cluster (clusters5) ((np.array (99)) py.none 2.0 py.none))
         (assertEqual
             $new-clusters
-            ()
+            Nil
         )
     )
 )
@@ -323,71 +378,67 @@
 (Test bisecting-kmeans.bisect-cluster.test1)
 
 ;; ========================================================================
-;; ========== Test bisecting-kmeans.recursive-bisecting-kmeans ============
+;; =================== Test bisecting-kmeans.assign ======================
 ;; ========================================================================
 
 (=
-    (bisecting-kmeans.recursive-bisecting-kmeans.test1)
+    (bisecting-kmeans.assign.test1)
     (let
-        $init-cluster
-        (bisecting-kmeans.compute-initial-cluster (X6))
+        $assignments
+        (bisecting-kmeans.assign (X-assign) (test-clusters-assign))
+        (np.assertAllClose
+            $assignments
+            (np.array (0 0 1 1))
+        )
+    )
+)
+(Test bisecting-kmeans.assign.test1)
+
+(=
+    (bisecting-kmeans.assign.test2)
+    (let
+        $X-test
+        (np.array (
+            (4.0 4.0)
+            (6.0 6.0)
+            (0.9 0.9)
+            (3.0 3.0)
+        ))
         (let
-            $init-hierarchy
-            (append py.none $init-cluster)
-            (let
-                $hierarchy
-                (bisecting-kmeans.recursive-bisecting-kmeans (X6) $init-cluster 1 10 $init-hierarchy)
-                (np.assertAllClose (len $hierarchy) 1)
+            $assignments
+            (bisecting-kmeans.assign $X-test (test-clusters-assign))
+            (np.assertAllClose
+                $assignments
+                (np.array (1 1 0 0))
             )
         )
     )
 )
-(Test bisecting-kmeans.recursive-bisecting-kmeans.test1)
-
-(=
-    (bisecting-kmeans.recursive-bisecting-kmeans.test2)
-    (let
-        $init-cluster
-        (bisecting-kmeans.compute-initial-cluster (X6))
-        (let
-            $init-hierarchy
-            (append py.none $init-cluster)
-            (let
-                $hierarchy
-                (bisecting-kmeans.recursive-bisecting-kmeans (X6) $init-cluster 3 10 $init-hierarchy)
-                (np.assertAllClose (len $hierarchy) 3)
-            )
-        )
-    )
-)
-(Test bisecting-kmeans.recursive-bisecting-kmeans.test2)
+(Test bisecting-kmeans.assign.test2)
 
 ;; ========================================================================
-;; ======================= Test bisecting-kmeans.fit ======================
+;; ================= Test bisecting-kmeans.fit ===========================
 ;; ========================================================================
 
 (=
     (bisecting-kmeans.fit.test1)
     (let
-        $output
-        (bisecting-kmeans.fit (X6) 1 10)
-        (np.assertAllClose (len $output) 1)
+        $X-fit
+        (np.array ((0.0 0.0) (0.0 1.0) (1.0 0.0) (1.0 1.0) (5.0 5.0) (5.0 6.0)))
+        (let
+            $hierarchy
+            (bisecting-kmeans.fit $X-fit 2 10)
+            (assertEqual
+                (>= (List.length $hierarchy) 1)
+                True
+            )
+        )
     )
 )
 (Test bisecting-kmeans.fit.test1)
 
-(=
-    (bisecting-kmeans.fit.test2)
-    (let
-        $output
-        (bisecting-kmeans.fit (X6) 3 10)
-        (np.assertAllClose (len $output) 3)
-    )
-)
-(Test bisecting-kmeans.fit.test2)
-
 ;; ========================================================================
-;; ==================== Test bisecting-kmeans.predict =====================
+;; ================= Test bisecting-kmeans.predict =======================
 ;; ========================================================================
 
 (=
@@ -412,3 +463,25 @@
     )
 )
 (Test bisecting-kmeans.predict.test1)
+
+;; ========================================================================
+;; ========== Test bisecting-kmeans.recursive-bisecting-kmeans ============
+;; ========================================================================
+
+(=
+    (bisecting-kmeans.recursive-bisecting-kmeans.test1)
+    (let
+        $init-cluster
+        (bisecting-kmeans.compute-initial-cluster (X6))
+        (let
+            $init-hierarchy
+            (Cons $init-cluster Nil)
+            (let
+                $hierarchy
+                (bisecting-kmeans.recursive-bisecting-kmeans (X6) $init-cluster 1 10 $init-hierarchy)
+                (np.assertAllClose (List.length $hierarchy) 1)
+            )
+        )
+    )
+)
+(Test bisecting-kmeans.recursive-bisecting-kmeans.test1)


### PR DESCRIPTION
Refactor bisecting k-means to use typed List with Cons/Nil constructors

- Update bisecting_kmeans.metta to use proper List type from linkedlist module
- Replace generic list operations with typed List.* functions
- Updated API doc accordingly
